### PR TITLE
Edited existing source code to accommodate DEcreasing the color intensity with Shift key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@ Generate custom profile activity for your profile READMEs
 
 ## How To Use
 
-- Click on the squares to change the colors
-- Press Ctrl key and hover on the squares to change the colors
+### Modifying Individual Squares
+- Click on a square to increase its intensity (darken its color)
+- Press and hold the [SHIFT] key and click a square to decrease its intensity (lighten its color)
+
+### Modifying Multiple Squares
+- Press and hold the [CTRL] key ([CMD] key on Mac) and move your mouse cursor over the squares you wish to increase in intensity (darken)
+- Press and hold both the [CTRL] key ([CMD] key on Mac) and the [SHIFT] key, then move your mouse cursor over the squares you wish to decrease in intensity (lighten)
+
 
 <div align="center">
     <img src="https://raw.githubusercontent.com/omidnikrah/profile-activity-generator/master/demo.png" />

--- a/js/generator.js
+++ b/js/generator.js
@@ -6,6 +6,7 @@ class Generator {
     this.resetActivityButton = document.getElementById('reset-activity-btn');
     this.daysActivity = {};
     this.isCtrlPressed = false;
+    this.isShiftPressed = false;
     this.renderActivity(7, 52, 16);
     for (let i = 0; i < this.days.length; i++) {
       this.days[i].addEventListener('click', (event) => this.handleDayClick(event, i), false);
@@ -38,12 +39,19 @@ class Generator {
     if (event.which === 91) {
       this.isCtrlPressed = true;
     }
+    if (event.which === 16) {
+      this.isShiftPressed = true;
+    }
   }
 
   handleKeyUp = (event) => {
     if (event.which === 91) {
       this.isCtrlPressed = false;
     }
+    if (event.which === 16) {
+      this.isShiftPressed = false;
+    }
+
   }
 
   handleDayHover = (event, index) => {
@@ -52,9 +60,12 @@ class Generator {
     }
   }
 
-  handleDayClick = (event, index) => {
-    this.daysActivity[index] = this.daysActivity[index] ? this.daysActivity[index] + 1 : 1;
+  handleDayClick = (event, index, modifier=1-(this.isShiftPressed*2)) => {
+    this.daysActivity[index] = this.daysActivity[index] ? Math.max(0, Math.min(4, this.daysActivity[index] + modifier)) : +(!this.isShiftPressed);
     switch(this.daysActivity[index]) {
+      case 0:
+        event.target.setAttribute('fill', '#ebedf0');
+        break;
       case 1:
         event.target.setAttribute('fill', '#c6e48b');
         break;


### PR DESCRIPTION
Edited existing source code to accommodate DEcreasing the color intensity by holding shift key (works with both single click event and ctrl/cmd+hover) by the following:

This resolves Issue #1.

 - Added `isShiftPressed` to constructor
 - Appended `isShiftPressed` handlers to `handleKeyDown` and `handleKeyUp`
 - Added additional, optional parameter to `handleDayClick` (if omitted, defaults to previous behavior (value===`1`). If shift key is depressed, converts value to `-1`. This is what is added to increment/decrement the storage array instead of the simple `+1`. This is done with a mathematical operation for its speed advantage over a conditional. This is done in the parameter so as not to disrupt the previous behavior/any existing calls to the method.
 - Added `min`/`max` check (JS doesn't have a native clamp routine. No idea why.) to ensure value bottoms out at `0` and maxes out at `4`. This prevents numbers out of scope when using the ctrl/cmd+hover (which can result in the necessity of a bunch of extraneous clicks before a box is alterable again)
 - Altered default value of `index` (previously `1`) to the coerced-numeric value of `isShiftPressed` (meaning default will be `0` if it IS depressed). This prevents some boxes decrementing while hitherto-untouched boxes increment, when the user is holding shift (which is obnoxious. Try it without.). And, finally,
 - Added fifth case to switch statement to handle `0`: the default "off" state color of `#ebedf0`